### PR TITLE
Bugfix android - loadMoreItems not is called

### DIFF
--- a/grid-view.android.ts
+++ b/grid-view.android.ts
@@ -179,7 +179,7 @@ class GridViewScrollListener extends android.support.v7.widget.RecyclerView.OnSc
         }
 
         const lastVisibleItemPos = (view.getLayoutManager() as android.support.v7.widget.GridLayoutManager).findLastCompletelyVisibleItemPosition();
-        const itemCount = owner.items.length;
+        const itemCount = owner.items.length - 1;
         if (lastVisibleItemPos === itemCount) {
             owner.notify({
                 eventName: GridViewBase.loadMoreItemsEvent,


### PR DESCRIPTION
lastVisibleItemPos starts with 0, so item position to test should be items.length - 1.