### PR TITLE
fix: orientationProperty wasn't registered to GridViewBase

### DIFF
--- a/grid-view-common.ts
+++ b/grid-view-common.ts
@@ -153,3 +153,4 @@ export const orientationProperty = new Property<GridViewBase, Orientation>({
     },
     valueConverter: converter
 });
+orientationProperty.register(GridViewBase);


### PR DESCRIPTION
Changes to the orientation wasn't applied to the nativeView because I forgot one line in my previous PR...

```
orientationProperty.register(GridViewBase);
```