### PR TITLE
Use isListLikeIterable from @angular/core

### DIFF
--- a/angular/grid-view-comp.ts
+++ b/angular/grid-view-comp.ts
@@ -37,6 +37,7 @@ import {
     TemplateRef,
     ViewChild,
     ViewContainerRef,
+    ɵisListLikeIterable as isListLikeIterable,
 } from "@angular/core";
 import { ObservableArray } from "tns-core-modules/data/observable-array";
 import { profile } from "tns-core-modules/profiling";
@@ -51,7 +52,6 @@ import {
   GridView,
 } from "../grid-view";
 
-import { isListLikeIterable } from "nativescript-angular/collection-facade";
 import {
   getSingleViewRecursive,
   isKnownView,


### PR DESCRIPTION
NativeScript-Grid-View breaks when used with the latest release of nativescript-angular. They stopped using their own isListLikeIterable to use the one from @angular/core.

This now imports isListLikeIterable from @angular/core like nativescript-angular does.