### PR TITLE
Fixes an android crash

### DIFF
--- a/grid-view.android.ts
+++ b/grid-view.android.ts
@@ -216,13 +216,16 @@ class GridViewScrollListener extends android.support.v7.widget.RecyclerView.OnSc
         }
 
         const lastVisibleItemPos = (view.getLayoutManager() as android.support.v7.widget.GridLayoutManager).findLastCompletelyVisibleItemPosition();
-        const itemCount = owner.items.length - 1;
-        if (lastVisibleItemPos === itemCount) {
-            owner.notify({
-                eventName: GridViewBase.loadMoreItemsEvent,
-                object: owner
-            });
+        if (owner && owner.items) {
+            const itemCount = owner.items.length - 1;
+            if (lastVisibleItemPos === itemCount) {
+                owner.notify({
+                    eventName: GridViewBase.loadMoreItemsEvent,
+                    object: owner
+                });
+            }
         }
+        
     }
 
     public onScrollStateChanged(view: android.support.v7.widget.RecyclerView, newState: number) {


### PR DESCRIPTION
Specifically, if you have a view with multiple tabs and you are on a
tab that is not the tab containing the GridView, and you use the App
Switcher to switch to another app and then BACK to your app, it will
crash because owner.items is undefined. Switching the apps appears to
lose the context if the tab you are on is not the tab containing the
Grid View. So, this is a simple check to avoid the crash.