### PR TITLE
feat: add onscroll listener for android and ios

### DIFF
--- a/grid-view-common.ts
+++ b/grid-view-common.ts
@@ -43,6 +43,7 @@ export abstract class GridViewBase extends View implements GridViewDefinition {
     public static itemLoadingEvent = "itemLoading";
     public static itemTapEvent = "itemTap";
     public static loadMoreItemsEvent = "loadMoreItems";
+    public static scrollEvent = "scroll";
     public static knownFunctions = ["itemTemplateSelector", "itemIdGenerator"]; // See component-builder.ts isKnownFunction
 
     public _defaultTemplate: KeyedTemplate = {

--- a/grid-view.android.ts
+++ b/grid-view.android.ts
@@ -1,4 +1,4 @@
-﻿/*! *****************************************************************************
+/*! *****************************************************************************
 Copyright (c) 2018 Tangra Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ import {
     rowHeightProperty,
 } from "./grid-view-common";
 
-import { GridItemEventData, Orientation } from ".";
+import { GridItemEventData, Orientation, ScrollEventData } from ".";
 
 export * from "./grid-view-common";
 
@@ -247,6 +247,13 @@ function initGridViewScrollListener() {
             if (!owner) {
                 return;
             }
+
+            owner.notify<ScrollEventData>({
+                eventName: GridViewBase.scrollEvent,
+                object: owner,
+                scrollX: dx,
+                scrollY: dy,
+            });
 
             const lastVisibleItemPos = (view.getLayoutManager() as android.support.v7.widget.GridLayoutManager).findLastCompletelyVisibleItemPosition();
             if (owner && owner.items) {

--- a/grid-view.d.ts
+++ b/grid-view.d.ts
@@ -45,3 +45,10 @@ export interface GridItemEventData extends EventData {
     index: number;
     view: View;
 }
+
+export interface ScrollEventData extends EventData {
+    eventName: string;
+    object: GridView;
+    scrollX: number;
+    scrollY: number;
+}

--- a/grid-view.ios.ts
+++ b/grid-view.ios.ts
@@ -28,7 +28,7 @@ import {
     paddingTopProperty,
 } from "./grid-view-common";
 
-import { GridItemEventData, Orientation } from ".";
+import { GridItemEventData, Orientation, ScrollEventData } from ".";
 
 export * from "./grid-view-common";
 
@@ -78,6 +78,14 @@ export class GridView extends GridViewBase {
 
     get _childrenCount(): number {
         return this._map.size;
+    }
+
+    get horizontalOffset(): number {
+        return this.nativeViewProtected.contentOffset.x;
+    }
+
+    get verticalOffset(): number {
+        return this.nativeViewProtected.contentOffset.y;
     }
 
     public [paddingTopProperty.getDefault](): number {
@@ -357,5 +365,16 @@ class UICollectionViewDelegateImpl extends NSObject implements UICollectionViewD
         cell.highlighted = false;
 
         return indexPath;
+    }
+
+    public scrollViewDidScroll(collectionView: UICollectionView) {
+         const owner = this._owner.get();
+
+         owner.notify<ScrollEventData>({
+             object: owner,
+             eventName: "scroll",
+             scrollX: owner.horizontalOffset,
+             scrollY: owner.verticalOffset
+         });
     }
 }


### PR DESCRIPTION
This implementation adds onscroll listener for android and ios.
I referenced the pull request #34 for the ios part.

With this, for example, you can make a scroll bar which cannot be activated programmatically on android.( see <https://stackoverflow.com/a/27298868/5272836>)